### PR TITLE
Only override CMake variables if not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,15 @@ IF(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/base.cmake")
   MESSAGE(FATAL_ERROR "\nPlease run the following command first:\ngit submodule update --init\n")
 ENDIF()
 
-set(CMAKE_BUILD_TYPE "Release")
-set(PYTHON_EXECUTABLE "/usr/bin/python3") # specify python3 so that Debian Buster passes
-set(CMAKE_INSTALL_LIBDIR "lib/")
+IF(NOT DEFINED CMAKE_BUILD_TYPE)
+  SET(CMAKE_BUILD_TYPE "Release")
+ENDIF()
+IF(NOT DEFINED PYTHON_EXECUTABLE)
+  SET(PYTHON_EXECUTABLE "/usr/bin/python3") # specify python3 so that Debian Buster passes
+ENDIF()
+IF(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  SET(CMAKE_INSTALL_LIBDIR "lib/")
+ENDIF()
 
 # Disable -Werror on Unix for now.
 SET(CXX_DISABLE_WERROR True)


### PR DESCRIPTION
This repo adds several overrides for CMake variables that are not included in the upstream source. In particular, `PYTHON_EXECUTABLE` is hardcoded to `/usr/bin/python3`, which is not correct on every distribution. A simple fix is to only set the variables if they are not defined by the user.

Ideally, this found be fixed upstream by having the build script request the correct Python version, but for some reason they use a custom FindPython script that doesn't support that.